### PR TITLE
PlanBuild mod compatibilty

### DIFF
--- a/Building/Building.cs
+++ b/Building/Building.cs
@@ -125,7 +125,8 @@ public class Building : BaseUnityPlugin
 			}
 			__instance.GetComponent<ZNetView>().GetZDO().Set("BuildingSkill FreeBuild", forFree);
 
-			Player.m_localPlayer.RaiseSkill("Building");
+			if (Player.m_localPlayer.GetRightItem() != null && !Player.m_localPlayer.GetRightItem().m_shared.m_name.ToLower().Contains("blueprint"))
+				Player.m_localPlayer.RaiseSkill("Building");
 		}
 	}
 


### PR DESCRIPTION
Issue was that when using a PlanBuild's mod Blueprint Rune, thousands of pieces would be placed instantly at no cost at all, increasing Building skill instantly too many times.

This will check if the Blueprint rune is the currently equipped item before raising the skill.